### PR TITLE
Update common-lib jdk11 with tools

### DIFF
--- a/common-lib/openjdk-11/Dockerfile
+++ b/common-lib/openjdk-11/Dockerfile
@@ -3,12 +3,18 @@ USER root
 
 # install build tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
     ca-certificates \
     curl \
     netbase \
     wget \
     vim \
     git \
+    jq \
+    tar \
+    zip \
+    unzip \
+    gzip \
     gnupg \
     dirmngr
 


### PR DESCRIPTION
so that tooling matches what is available on the publish-deploy coontainers